### PR TITLE
[HT-74] set timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package.json ./
 
-RUN ["yarn"]
+RUN ["yarn", "install", "--network-timeout", "1000000"]
 
 COPY . .
 


### PR DESCRIPTION
На докерхабе со стандартным network-timeout не успевает скачаться material-ui, из-за этого падает с ошибкой подключения.

Исправленная версия работает, проверено.