### PR TITLE
Fixed hobbies on the main page

### DIFF
--- a/static/redux/actions/mainPageActions.js
+++ b/static/redux/actions/mainPageActions.js
@@ -7,7 +7,7 @@ import { sortByTypeMonitization } from '../../utils/functions';
 export const getHobbies = () => (dispatch) => {
     axios.get(`/restapi/hobby/all`).then(res => {
         let hobbies = sortByTypeMonitization(res.data, 0);
-        if (hobbies.length === 0) {
+        if (hobbies.length < 3) {
             hobbies = res.data.slice(0, 10);
         }
         let promise = dispatch(setHobbiesTop(hobbies));


### PR DESCRIPTION
На главной странице не отображались хобби из продовой базы, поскольку в фикстурах есть есть 2 хобби с нулевым тарифом (который "top"), из-за чего ограничение `hobbies.length === 0` не выполнялось. Выставлено другое ограничение, чтобы не учитывать фикстурные хобби. 

(Временное решение, пока не прикручена монетизация)