### PR TITLE
Slot pic Background color fix

### DIFF
--- a/static/components/MainPage/Slot/Slot.module.css
+++ b/static/components/MainPage/Slot/Slot.module.css
@@ -14,6 +14,7 @@
     object-fit: cover;
     box-sizing: border-box;
     border-radius: 30px;
+    background-color: #178fd642;
 }
 
 .slotDescription {
@@ -49,7 +50,8 @@
     height: 16px;
     margin-top: 4px;
     font-size: 10px;
-    line-height: 16px;letter-spacing: 0.4px;
+    line-height: 16px;
+    letter-spacing: 0.4px;
 }
 
 .metro {


### PR DESCRIPTION
- поменял дефолтную заливку для иконки в слоте хобби (для того, чтобы белые элементы на аватарах без фона не сливались с цветом страницы)

не знаю, сгодится ли такое же решения для слайдера - пока не трогал