### PR TITLE
Fixed answers in provider cabinet

### DIFF
--- a/static/components/Common/FeedbackStatistic.js
+++ b/static/components/Common/FeedbackStatistic.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function HalfRating(props) {
     const classes = useStyles();
-    const rating = props.rating;
+    const rating = props.rating ? props.rating.toFixed(2) : 0;
     return (
         <div className={classes.root}>
                 <Rating className={classes.stars} size='small' name="half-rating-read" defaultValue={rating} precision={0.5}

--- a/static/components/ProviderCabinet/ProviderCabinet.jsx
+++ b/static/components/ProviderCabinet/ProviderCabinet.jsx
@@ -2,15 +2,16 @@ import React, { Component } from "react";
 import { Redirect } from "react-router-dom";
 import { connect } from "react-redux";
 import style from "./ProviderCabinet.module.css";
-import { DialogAddHobbyForm } from "./DialogAddHobbyForm/DialogAddHobbyForm";
 import { initializeProviderCabinet, setIsProviderInCabinet } from "../../redux/actions/providerActions";
 import Preloader from "../Common/Preloader/Preloader";
-import { AddHobbyCard } from "./AddHobbyCard/AddHobbyCard";
-import UserAvatar from "../UserCabinet/UserInfoCard/UserAvatar/UserAvatar";
 import ProviderInfo from "./ProviderInfo/ProviderInfo";
-import UserInfoCard from "../UserCabinet/UserInfoCard/UserInfoCard";
-import Feedback from "../HobbyCard/Feedback/Feedback";
-import CommentsList from "../HobbyCard/Feedback/CommentsList";
+import ProviderCommentsList from "./ProviderCommentsList";
+
+
+function getHobbyIds(relatedIds) {
+    return relatedIds ? relatedIds.map(ids => ids.hobbyId) : [];
+}
+
 
 class ProviderCabinet extends React.Component {
     componentDidMount() {
@@ -34,7 +35,7 @@ class ProviderCabinet extends React.Component {
                     <ProviderInfo avatar={this.props.avatar} name={this.props.name} email={this.props.email} phone={this.props.phone}/>
                 </div>
                 <div className={style.feedbackHeader}>Отзывы на ваши хобби и ваши ответы на них:</div>
-                <CommentsList comments={this.props.comments.commentsInfo || []} isProvider={true} isOwner={true}/>
+                <ProviderCommentsList comments={this.props.comments.commentsInfo || []} hobbyIds={getHobbyIds(this.props.comments.commentsIds)}/>
             </div>
         );
     }

--- a/static/components/ProviderCabinet/ProviderCommentsList.jsx
+++ b/static/components/ProviderCabinet/ProviderCommentsList.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import style from '../HobbyCard/Feedback/Feedback.css';
+import CommentText from '../HobbyCard/Feedback/CommentText';
+
+const CommentsList = (props) => {
+    return (<ul className={style.list}>
+            {
+                props.comments.map(function (item, index) {
+                    let isHaveAnswer = true;
+                    if ((item.answer) == null){
+                        isHaveAnswer = false;
+                    }
+                    return <li key={index} className={style.container}>
+                        <CommentText comment={item} isProviderAuth={true} isHaveAnswer= {item.answer != null}
+                                     isOwner = {true} isItAnswerProvider={false} hobbyId={props.hobbyIds[index]}/>
+                        {item.answer &&
+                        <CommentText comment={item.answer} isProviderAuth={props.isProvider} isItAnswerProvider={true}/>}
+                    </li>;
+                })
+            }
+        </ul>
+    );
+};
+
+export default CommentsList;

--- a/static/redux/actions/hobbyActions.js
+++ b/static/redux/actions/hobbyActions.js
@@ -69,7 +69,7 @@ export const addProviderResponse = (hobbyId, body, relatedId) => (dispatch) => {
         text: body.text,
         datetime: body.datetime
     };
-    commentApi.providerAddAnswer(obj, hobbyId, relatedId)
+    return commentApi.providerAddAnswer(obj, hobbyId, relatedId)
         .then(res =>{
             if(res.ok){
                 axios.get(`/restapi/hobby/comments?id=${hobbyId}`)


### PR DESCRIPTION
Исправлены некоторые мелкие недочёты:
* Теперь корректно обрабатываются ответы партнёра на комментарии, оставляемые из своего кабинета: ответ сохраняется, список комментариев обновляется и ререндерится.
* Время отправки комментария отображается в более удобном формате: "dd.mm.yyyy hh:mm".
* При обновлении рейтинг иногда может стать длинной десятичной дробью с >10 знаками после запятой, которые все отображались и в слотах, и на страничке хобби (например, 4.66666666666667). Теперь он везде при отображении округляется до 2 знаков после запятой.